### PR TITLE
Add LED trigger scripts based on cylinder rotation and movie protocol

### DIFF
--- a/AnimateCylinderTexture.cs
+++ b/AnimateCylinderTexture.cs
@@ -14,6 +14,9 @@ public class AnimateCylinderTexture : MonoBehaviour
 
     public float offsetEl= 0.1f;
 
+    [Header("Debug")]
+    public bool showDebugLog = false;
+
     private int repeats = 1; // use repeating velocities to ensure repeats
     private Material cylinderMaterial;
     private float elevation;
@@ -21,6 +24,7 @@ public class AnimateCylinderTexture : MonoBehaviour
     private float rotDir = 1.0f;
     private int vel = 0;
     private float waitTime = 0;
+    private int _debugFrameCount = 0;
 
     // Current azimuth in degrees (0-360), readable by other scripts (e.g., LED trigger)
     private float _azimuthDeg;
@@ -42,11 +46,17 @@ public class AnimateCylinderTexture : MonoBehaviour
     void Start()
     {
         cylinderMaterial = Resources.Load(Janelia.CylinderBackgroundResources.MaterialName, typeof(Material)) as Material;
-        //Resources.Load(Janelia.CylinderBackgroundResources.MaterialName, typeof(Material)) as Material
 
         if (cylinderMaterial == null)
         {
-            Debug.LogError("Could not load material'" + Janelia.CylinderBackgroundResources.MaterialName + "'");
+            Debug.LogError("Could not load material '" + Janelia.CylinderBackgroundResources.MaterialName + "'");
+        }
+
+        if (showDebugLog)
+        {
+            Debug.Log($"[AnimateCylinderTexture] Start: material={(cylinderMaterial != null ? "LOADED" : "NULL")}, " +
+                      $"vRotDeg_per_sec.Length={vRotDeg_per_sec?.Length}, sweepRepeatVec.Length={sweepRepeatVec?.Length}, " +
+                      $"delaySeconds={delaySeconds}, offsetTex={offsetTex}, numElevationSteps={numElevationSteps}");
         }
 
         //reset texture based on offset
@@ -69,9 +79,15 @@ public class AnimateCylinderTexture : MonoBehaviour
 
     void Update()
     {
+        _debugFrameCount++;
+
         // Done with all velocities
         if (vel >= vRotDeg_per_sec.Length || vel >= sweepRepeatVec.Length)
+        {
+            if (showDebugLog && _debugFrameCount <= 5)
+                Debug.Log($"[AnimateCylinderTexture] Frame {_debugFrameCount}: SKIPPED — vel={vel} >= array length (vRot={vRotDeg_per_sec.Length}, sweep={sweepRepeatVec.Length})");
             return;
+        }
 
         //check if a velocity has been completed
         if (currentStep > repeats * 2 * sweepRepeatVec[vel] * numElevationSteps)
@@ -123,12 +139,23 @@ public class AnimateCylinderTexture : MonoBehaviour
 
                 cylinderMaterial.SetTextureOffset("_MainTex", offset);
 
+                if (showDebugLog && _debugFrameCount <= 5)
+                    Debug.Log($"[AnimateCylinderTexture] Frame {_debugFrameCount}: ROTATING — x={x:F4}, y={y:F4}, azimuth={_azimuthDeg:F1}°, vel[{vel}]={vRotDeg_per_sec[vel]}, step={currentStep}, dTime={dTime:F3}");
+
                 //log values
                 _currentLogEntry.xpos = x;
                 _currentLogEntry.ypos = y;
                 Janelia.Logger.Log(_currentLogEntry);
             }
+            else if (showDebugLog && _debugFrameCount <= 5)
+            {
+                Debug.Log($"[AnimateCylinderTexture] Frame {_debugFrameCount}: STOPPED — currentStep*vel={currentStep*vel} > limit={repeats * 2 * numElevationSteps * sweepRepeatVec[sweepRepeatVec.Length-1] * vRotDeg_per_sec.Length}");
+            }
 
+        }
+        else if (showDebugLog && _debugFrameCount <= 5)
+        {
+            Debug.Log($"[AnimateCylinderTexture] Frame {_debugFrameCount}: WAITING — material={(cylinderMaterial != null ? "OK" : "NULL")}, Time.time={Time.time:F3}, waitTime+delay={waitTime+delaySeconds:F3}");
         }
 
     }

--- a/AnimateCylinderTexture.cs
+++ b/AnimateCylinderTexture.cs
@@ -1,0 +1,210 @@
+using System;
+using UnityEngine;
+
+public class AnimateCylinderTexture : MonoBehaviour
+{
+    [Header("Sweep settings (degrees)")]
+    public float sweepStartDeg = 90f;
+    public float sweepEndDeg   = 270f;   // texture sweeps only within [start, end]
+    public bool allowWrapRange = false;  // if true, a range like 300→60 is allowed via wrap
+
+    [Header("Velocity / repeats / stepping")]
+    public float[] vRotDeg_per_sec;
+    public int[] sweepRepeatVec;         // how many back-and-forths per elevation step, per vel
+    public float numElevationSteps = 10.0f;
+
+    [Header("Delays / offsets")]
+    public float delaySeconds = 10f;
+    public float offsetTexDeg = 0f;      // optional extra phase offset in degrees (was -90)
+    public float offsetEl = 0.1f;        // starting elevation in [0,1]
+
+    // internal state
+    private int repeats = 1; // keep original intent (repeating velocities to ensure repeats)
+    private Material cylinderMaterial;
+    private float elevation;
+    private int vel = 0;                   // index into vRotDeg_per_sec
+    private float waitTime = 0f;
+
+    private float azimuthDeg;              // current azimuth (deg) constrained to [start,end] (or wrapped range)
+    public float AzimuthDeg => azimuthDeg; // read-only access for other scripts
+    private float rotDir = +1f;            // +1 forward, -1 backward within the sweep window
+    private int halfSweepCount = 0;        // increments every time we hit an end (start or end)
+    private int elevationStepIndex = 0;    // how many elevation steps completed
+
+    //set up logging
+    [Serializable]
+    private class textureLogEntry : Janelia.Logger.Entry
+    {
+        public float xpos;
+        public float ypos;
+    };
+
+    private textureLogEntry _currentLogEntry = new textureLogEntry();
+
+    void Start()
+    {
+        cylinderMaterial = Resources.Load(Janelia.CylinderBackgroundResources.MaterialName, typeof(Material)) as Material;
+        if (cylinderMaterial == null)
+        {
+            Debug.LogError("Could not load material '" + Janelia.CylinderBackgroundResources.MaterialName + "'");
+        }
+
+        // Normalize/validate sweep limits
+        sweepStartDeg = NormalizeDeg(sweepStartDeg);
+        sweepEndDeg   = NormalizeDeg(sweepEndDeg);
+
+        if (!allowWrapRange && sweepEndDeg < sweepStartDeg)
+        {
+            // if wrap not allowed and start > end, swap so we have a proper interval
+            float tmp = sweepStartDeg; sweepStartDeg = sweepEndDeg; sweepEndDeg = tmp;
+        }
+
+        elevation = Mathf.Clamp01(offsetEl);
+        azimuthDeg = sweepStartDeg; // start at the beginning of the window
+
+        ApplyTextureOffset(); // apply initial offset & log
+        waitTime = Time.time; // start delay window
+    }
+
+    void Update()
+    {
+        // Done with all velocities?
+        if (vel >= vRotDeg_per_sec.Length || vel >= sweepRepeatVec.Length)
+            return;
+
+        // honor delay between velocity blocks
+        if (Time.time < (waitTime + delaySeconds))
+            return;
+
+        float speedDegPerSec = vRotDeg_per_sec[vel];
+        float dAz = speedDegPerSec * rotDir * Time.deltaTime;
+
+        // Integrate azimuth within the sweep window
+        if (IsWrappedRange())
+        {
+            // sweep across a wrapped interval (e.g., 300 → 60)
+            azimuthDeg = Wrap(azimuthDeg + dAz);
+
+            // Check bounds along the wrapped arc
+            if (!OnWrappedArc(azimuthDeg))
+            {
+                // We crossed out of the arc; clamp to boundary and flip
+                // Determine which end was crossed by checking direction
+                float target = (rotDir > 0f) ? sweepEndDeg : sweepStartDeg;
+                azimuthDeg = target;
+                rotDir *= -1f;
+                OnHitEnd();
+            }
+        }
+        else
+        {
+            // simple clamped interval [start, end]
+            azimuthDeg += dAz;
+
+            if (azimuthDeg >= sweepEndDeg)
+            {
+                azimuthDeg = sweepEndDeg;
+                rotDir = -1f;
+                OnHitEnd();
+            }
+            else if (azimuthDeg <= sweepStartDeg)
+            {
+                azimuthDeg = sweepStartDeg;
+                rotDir = +1f;
+                OnHitEnd();
+            }
+        }
+
+        // Apply texture coords
+        ApplyTextureOffset();
+
+        // Stop condition (kept similar spirit to your original)
+        // After finishing all elevation steps for all velocities, we stop updating.
+        if (elevationStepIndex >= Mathf.RoundToInt(numElevationSteps))
+        {
+            // advance to the next velocity once we finish all steps at this velocity
+            vel++;
+            if (vel < vRotDeg_per_sec.Length && vel < sweepRepeatVec.Length)
+            {
+                // reset for next velocity
+                waitTime = Time.time;
+                elevationStepIndex = 0;
+                halfSweepCount = 0;
+                rotDir = +1f;
+                azimuthDeg = sweepStartDeg;
+            }
+        }
+    }
+
+    private void OnHitEnd()
+    {
+        halfSweepCount++;
+
+        // Each back-and-forth is two hits; after N back-and-forths, step elevation
+        int neededHalfSw = 2 * sweepRepeatVec[vel] * repeats;
+        if (halfSweepCount % neededHalfSw == 0)
+        {
+            // step elevation (evenly across (1 - offsetEl) range)
+            elevationStepIndex++;
+            if (numElevationSteps > 0)
+            {
+                elevation = Mathf.Clamp01(offsetEl + (1f - offsetEl) * (elevationStepIndex / numElevationSteps));
+            }
+            else
+            {
+                elevation = Mathf.Clamp01(offsetEl);
+            }
+
+            // restart from the start side moving forward
+            rotDir = +1f;
+            azimuthDeg = IsWrappedRange() ? sweepStartDeg : sweepStartDeg;
+        }
+    }
+
+    private void ApplyTextureOffset()
+    {
+        // Convert azimuth (deg) to texture x in [0,1], with optional extra phase offset
+        float xDeg = Wrap(azimuthDeg + offsetTexDeg);
+        float x = xDeg / 360f;
+        float y = elevation;
+
+        Vector2 offset = new Vector2(x, y);
+        if (cylinderMaterial != null)
+        {
+            cylinderMaterial.SetTextureOffset("_MainTex", offset);
+
+            // log values
+            _currentLogEntry.xpos = x;
+            _currentLogEntry.ypos = y;
+            Janelia.Logger.Log(_currentLogEntry);
+        }
+    }
+
+    // --- helpers ---
+    private static float NormalizeDeg(float deg)
+    {
+        // map to [0,360)
+        deg = deg % 360f;
+        if (deg < 0f) deg += 360f;
+        return deg;
+    }
+
+    private static float Wrap(float deg)
+    {
+        if (deg >= 360f || deg < 0f) deg = NormalizeDeg(deg);
+        return deg;
+    }
+
+    private bool IsWrappedRange()
+    {
+        // true if we intentionally allow a range that crosses 0/360
+        return allowWrapRange && sweepEndDeg < sweepStartDeg;
+    }
+
+    private bool OnWrappedArc(float d)
+    {
+        // For a wrapped arc (e.g., 300→60), points are on arc if d >= start OR d <= end
+        // (because the arc crosses 0)
+        return (d >= sweepStartDeg) || (d <= sweepEndDeg);
+    }
+}

--- a/AnimateCylinderTexture.cs
+++ b/AnimateCylinderTexture.cs
@@ -69,6 +69,10 @@ public class AnimateCylinderTexture : MonoBehaviour
 
     void Update()
     {
+        // Done with all velocities
+        if (vel >= vRotDeg_per_sec.Length || vel >= sweepRepeatVec.Length)
+            return;
+
         //check if a velocity has been completed
         if (currentStep > repeats * 2 * sweepRepeatVec[vel] * numElevationSteps)
         {

--- a/AnimateCylinderTexture.cs
+++ b/AnimateCylinderTexture.cs
@@ -3,33 +3,29 @@ using UnityEngine;
 
 public class AnimateCylinderTexture : MonoBehaviour
 {
-    [Header("Sweep settings (degrees)")]
-    public float sweepStartDeg = 90f;
-    public float sweepEndDeg   = 270f;   // texture sweeps only within [start, end]
-    public bool allowWrapRange = false;  // if true, a range like 300→60 is allowed via wrap
-
-    [Header("Velocity / repeats / stepping")]
     public float[] vRotDeg_per_sec;
-    public int[] sweepRepeatVec;         // how many back-and-forths per elevation step, per vel
+
+    public int[] sweepRepeatVec;
+
     public float numElevationSteps = 10.0f;
 
-    [Header("Delays / offsets")]
-    public float delaySeconds = 10f;
-    public float offsetTexDeg = 0f;      // optional extra phase offset in degrees (was -90)
-    public float offsetEl = 0.1f;        // starting elevation in [0,1]
+    public float delaySeconds = 10;
+    public float offsetTex = -90.0f;
 
-    // internal state
-    private int repeats = 1; // keep original intent (repeating velocities to ensure repeats)
+    public float offsetEl= 0.1f;
+
+    private int repeats = 1; // use repeating velocities to ensure repeats
     private Material cylinderMaterial;
     private float elevation;
-    private int vel = 0;                   // index into vRotDeg_per_sec
-    private float waitTime = 0f;
+    private int currentStep = 1;
+    private float rotDir = 1.0f;
+    private int vel = 0;
+    private float waitTime = 0;
 
-    private float azimuthDeg;              // current azimuth (deg) constrained to [start,end] (or wrapped range)
-    public float AzimuthDeg => azimuthDeg; // read-only access for other scripts
-    private float rotDir = +1f;            // +1 forward, -1 backward within the sweep window
-    private int halfSweepCount = 0;        // increments every time we hit an end (start or end)
-    private int elevationStepIndex = 0;    // how many elevation steps completed
+    // Current azimuth in degrees (0-360), readable by other scripts (e.g., LED trigger)
+    private float _azimuthDeg;
+    public float AzimuthDeg => _azimuthDeg;
+
 
     //set up logging
     [Serializable]
@@ -37,174 +33,100 @@ public class AnimateCylinderTexture : MonoBehaviour
     {
         public float xpos;
         public float ypos;
+
     };
 
     private textureLogEntry _currentLogEntry = new textureLogEntry();
 
+
     void Start()
     {
         cylinderMaterial = Resources.Load(Janelia.CylinderBackgroundResources.MaterialName, typeof(Material)) as Material;
+        //Resources.Load(Janelia.CylinderBackgroundResources.MaterialName, typeof(Material)) as Material
+
         if (cylinderMaterial == null)
         {
-            Debug.LogError("Could not load material '" + Janelia.CylinderBackgroundResources.MaterialName + "'");
+            Debug.LogError("Could not load material'" + Janelia.CylinderBackgroundResources.MaterialName + "'");
         }
 
-        // Normalize/validate sweep limits
-        sweepStartDeg = NormalizeDeg(sweepStartDeg);
-        sweepEndDeg   = NormalizeDeg(sweepEndDeg);
+        //reset texture based on offset
+        elevation = offsetEl;
+        float x = offsetTex / 360.0f;
+        float y = elevation;
 
-        if (!allowWrapRange && sweepEndDeg < sweepStartDeg)
-        {
-            // if wrap not allowed and start > end, swap so we have a proper interval
-            float tmp = sweepStartDeg; sweepStartDeg = sweepEndDeg; sweepEndDeg = tmp;
-        }
+        Vector2 offset = new Vector2(x, y);
 
-        elevation = Mathf.Clamp01(offsetEl);
-        azimuthDeg = sweepStartDeg; // start at the beginning of the window
+        cylinderMaterial.SetTextureOffset("_MainTex", offset);
 
-        ApplyTextureOffset(); // apply initial offset & log
-        waitTime = Time.time; // start delay window
+        // Store initial azimuth (normalized to 0-360)
+        _azimuthDeg = ((x % 1f) + 1f) % 1f * 360f;
+
+        //log values
+        _currentLogEntry.xpos = x;
+        _currentLogEntry.ypos = y;
+        Janelia.Logger.Log(_currentLogEntry);
     }
 
     void Update()
     {
-        // Done with all velocities?
-        if (vel >= vRotDeg_per_sec.Length || vel >= sweepRepeatVec.Length)
-            return;
-
-        // honor delay between velocity blocks
-        if (Time.time < (waitTime + delaySeconds))
-            return;
-
-        float speedDegPerSec = vRotDeg_per_sec[vel];
-        float dAz = speedDegPerSec * rotDir * Time.deltaTime;
-
-        // Integrate azimuth within the sweep window
-        if (IsWrappedRange())
+        //check if a velocity has been completed
+        if (currentStep > repeats * 2 * sweepRepeatVec[vel] * numElevationSteps)
         {
-            // sweep across a wrapped interval (e.g., 300 → 60)
-            azimuthDeg = Wrap(azimuthDeg + dAz);
-
-            // Check bounds along the wrapped arc
-            if (!OnWrappedArc(azimuthDeg))
+            vel+=1;
+            currentStep = 1;
+            elevation = offsetEl;
+            if (vel <= vRotDeg_per_sec.Length)
             {
-                // We crossed out of the arc; clamp to boundary and flip
-                // Determine which end was crossed by checking direction
-                float target = (rotDir > 0f) ? sweepEndDeg : sweepStartDeg;
-                azimuthDeg = target;
-                rotDir *= -1f;
-                OnHitEnd();
-            }
-        }
-        else
-        {
-            // simple clamped interval [start, end]
-            azimuthDeg += dAz;
-
-            if (azimuthDeg >= sweepEndDeg)
-            {
-                azimuthDeg = sweepEndDeg;
-                rotDir = -1f;
-                OnHitEnd();
-            }
-            else if (azimuthDeg <= sweepStartDeg)
-            {
-                azimuthDeg = sweepStartDeg;
-                rotDir = +1f;
-                OnHitEnd();
-            }
-        }
-
-        // Apply texture coords
-        ApplyTextureOffset();
-
-        // Stop condition (kept similar spirit to your original)
-        // After finishing all elevation steps for all velocities, we stop updating.
-        if (elevationStepIndex >= Mathf.RoundToInt(numElevationSteps))
-        {
-            // advance to the next velocity once we finish all steps at this velocity
-            vel++;
-            if (vel < vRotDeg_per_sec.Length && vel < sweepRepeatVec.Length)
-            {
-                // reset for next velocity
                 waitTime = Time.time;
-                elevationStepIndex = 0;
-                halfSweepCount = 0;
-                rotDir = +1f;
-                azimuthDeg = sweepStartDeg;
             }
         }
-    }
 
-    private void OnHitEnd()
-    {
-        halfSweepCount++;
-
-        // Each back-and-forth is two hits; after N back-and-forths, step elevation
-        int neededHalfSw = 2 * sweepRepeatVec[vel] * repeats;
-        if (halfSweepCount % neededHalfSw == 0)
+        if (cylinderMaterial & Time.time >= (waitTime+delaySeconds))
         {
-            // step elevation (evenly across (1 - offsetEl) range)
-            elevationStepIndex++;
-            if (numElevationSteps > 0)
+
+            float dTime = Time.time - (waitTime+delaySeconds);
+            float x = offsetTex/360.0f + dTime * rotDir * (vRotDeg_per_sec[vel] / 360.0f) % 1;
+
+            //check if a round has been completed
+            if (dTime * (vRotDeg_per_sec[vel] / 360.0f ) > currentStep)
             {
-                elevation = Mathf.Clamp01(offsetEl + (1f - offsetEl) * (elevationStepIndex / numElevationSteps));
+                if (currentStep % (2*sweepRepeatVec[vel]) == 0) // we finished the nth repeat, change elevation and reset direction
+                {
+                    elevation += (1-offsetEl) / numElevationSteps;
+                    rotDir = 1.0f;
+                }
+                else if (currentStep % 2 == 0) // finished an even round --> second of two repeats
+                {
+                    rotDir = 1.0f; // now change direction to +ve
+                }
+                else // finished an uneven round --> first of two repeats
+                {
+                    rotDir = -1.0f; // now change direction to -ve
+                }
+                currentStep += 1;
+
             }
-            else
+
+            float y = elevation;
+            Vector2 offset = new Vector2(x, y);
+
+            // Store current azimuth (normalized to 0-360)
+            _azimuthDeg = ((x % 1f) + 1f) % 1f * 360f;
+
+            //stop if done
+            if (currentStep*vel <= (repeats * 2 * numElevationSteps * sweepRepeatVec[sweepRepeatVec.Length-1] * vRotDeg_per_sec.Length))
             {
-                elevation = Mathf.Clamp01(offsetEl);
+
+                cylinderMaterial.SetTextureOffset("_MainTex", offset);
+
+                //log values
+                _currentLogEntry.xpos = x;
+                _currentLogEntry.ypos = y;
+                Janelia.Logger.Log(_currentLogEntry);
             }
 
-            // restart from the start side moving forward
-            rotDir = +1f;
-            azimuthDeg = IsWrappedRange() ? sweepStartDeg : sweepStartDeg;
         }
+
     }
 
-    private void ApplyTextureOffset()
-    {
-        // Convert azimuth (deg) to texture x in [0,1], with optional extra phase offset
-        float xDeg = Wrap(azimuthDeg + offsetTexDeg);
-        float x = xDeg / 360f;
-        float y = elevation;
-
-        Vector2 offset = new Vector2(x, y);
-        if (cylinderMaterial != null)
-        {
-            cylinderMaterial.SetTextureOffset("_MainTex", offset);
-
-            // log values
-            _currentLogEntry.xpos = x;
-            _currentLogEntry.ypos = y;
-            Janelia.Logger.Log(_currentLogEntry);
-        }
-    }
-
-    // --- helpers ---
-    private static float NormalizeDeg(float deg)
-    {
-        // map to [0,360)
-        deg = deg % 360f;
-        if (deg < 0f) deg += 360f;
-        return deg;
-    }
-
-    private static float Wrap(float deg)
-    {
-        if (deg >= 360f || deg < 0f) deg = NormalizeDeg(deg);
-        return deg;
-    }
-
-    private bool IsWrappedRange()
-    {
-        // true if we intentionally allow a range that crosses 0/360
-        return allowWrapRange && sweepEndDeg < sweepStartDeg;
-    }
-
-    private bool OnWrappedArc(float d)
-    {
-        // For a wrapped arc (e.g., 300→60), points are on arc if d >= start OR d <= end
-        // (because the arc crosses 0)
-        return (d >= sweepStartDeg) || (d <= sweepEndDeg);
-    }
 }

--- a/TalkToNiDaq_LED_CylinderRotation.cs
+++ b/TalkToNiDaq_LED_CylinderRotation.cs
@@ -8,12 +8,11 @@ public class TalkToNiDaq_LED_CylinderRotation : MonoBehaviour
     [Tooltip("Drag the GameObject with AnimateCylinderTexture here. If left empty, it will be found automatically.")]
     public AnimateCylinderTexture cylinderTexture;
 
-    [Header("LED Angle Ranges (signed degrees, -180 to 180)")]
-    [Tooltip("LED is ON when the cylinder azimuth falls within any of these ranges.")]
+    [Header("LED Angle Ranges (0 to 360 degrees)")]
+    [Tooltip("LED is ON when the cylinder azimuth falls within any of these ranges. Wrap-around is supported: e.g., from=330 to=30 means 330° through 0° to 30°.")]
     public AngleRange[] ledOnAngleRanges = new AngleRange[]
     {
-        new AngleRange { minAngle = 150f, maxAngle = 180f },
-        new AngleRange { minAngle = -180f, maxAngle = -150f }
+        new AngleRange { fromDeg = 330f, toDeg = 30f }
     };
 
     [Header("Debug")]
@@ -30,8 +29,8 @@ public class TalkToNiDaq_LED_CylinderRotation : MonoBehaviour
     [Serializable]
     public struct AngleRange
     {
-        [Range(-180f, 180f)] public float minAngle;
-        [Range(-180f, 180f)] public float maxAngle;
+        [Range(0f, 360f)] public float fromDeg;
+        [Range(0f, 360f)] public float toDeg;
     }
 
     private void Start()
@@ -113,20 +112,32 @@ public class TalkToNiDaq_LED_CylinderRotation : MonoBehaviour
             Debug.Log($"tracePD: {_currentLogEntry.tracePD}, imgFrameTrigger: {_currentLogEntry.imgFrameTrigger}, ledTrigger: {_currentLogEntry.ledTrigger}");
         }
 
-        // Get cylinder azimuth and convert from 0-360 to signed -180 to 180
-        float azimuth0to360 = cylinderTexture.AzimuthDeg;
-        float signedAzimuth = azimuth0to360 > 180f ? azimuth0to360 - 360f : azimuth0to360;
+        // Get cylinder azimuth directly in 0-360
+        float azimuth = cylinderTexture.AzimuthDeg;
 
-        // Check if azimuth falls within any LED-ON range
+        // Check if azimuth falls within any LED-ON range (supports wrap-around)
         bool ledOn = false;
         for (int i = 0; i < ledOnAngleRanges.Length; i++)
         {
-            float min = ledOnAngleRanges[i].minAngle;
-            float max = ledOnAngleRanges[i].maxAngle;
-            if (signedAzimuth >= min && signedAzimuth <= max)
+            float from = ledOnAngleRanges[i].fromDeg;
+            float to = ledOnAngleRanges[i].toDeg;
+            if (from <= to)
             {
-                ledOn = true;
-                break;
+                // Normal range: e.g., from=150 to=210
+                if (azimuth >= from && azimuth <= to)
+                {
+                    ledOn = true;
+                    break;
+                }
+            }
+            else
+            {
+                // Wrap-around range: e.g., from=330 to=30 means 330->360 and 0->30
+                if (azimuth >= from || azimuth <= to)
+                {
+                    ledOn = true;
+                    break;
+                }
             }
         }
 
@@ -143,7 +154,7 @@ public class TalkToNiDaq_LED_CylinderRotation : MonoBehaviour
         _writeData[2] = ledOn ? _outputParams.VoltageMax : _outputParams.VoltageMin;
 
         // Log
-        _currentLogEntry.cylinderAzimuth = signedAzimuth;
+        _currentLogEntry.cylinderAzimuth = azimuth;
         _currentLogEntry.ledState = ledOn ? 1.0 : 0.0;
         Janelia.Logger.Log(_currentLogEntry);
 
@@ -156,7 +167,7 @@ public class TalkToNiDaq_LED_CylinderRotation : MonoBehaviour
         }
         else if (showEachWrite)
         {
-            Debug.Log($"Azimuth: {signedAzimuth:F1}° | LED: {(ledOn ? "ON" : "OFF")} | Write: [{_writeData[0]:F2}, {_writeData[1]:F2}, {_writeData[2]:F2}]");
+            Debug.Log($"Azimuth: {azimuth:F1}° | LED: {(ledOn ? "ON" : "OFF")} | Write: [{_writeData[0]:F2}, {_writeData[1]:F2}, {_writeData[2]:F2}]");
         }
     }
 

--- a/TalkToNiDaq_LED_CylinderRotation.cs
+++ b/TalkToNiDaq_LED_CylinderRotation.cs
@@ -176,18 +176,22 @@ public class TalkToNiDaq_LED_CylinderRotation : MonoBehaviour
         if (_writeData == null || _outputParams == null)
             return;
 
-        double resetValue = _outputParams.VoltageMin;
-        int expectedNumWritten = _writeData.Length;
-
-        if (!Janelia.NiDaqMx.WriteToOutputs(_outputParams,
-                new double[] { resetValue, resetValue, resetValue },
-                ref expectedNumWritten))
+        try
         {
-            Debug.LogError("Reset write failed on destroy");
-            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
-        }
+            double resetValue = _outputParams.VoltageMin;
+            int expectedNumWritten = _writeData.Length;
 
-        Janelia.NiDaqMx.OnDestroy();
+            Janelia.NiDaqMx.WriteToOutputs(_outputParams,
+                    new double[] { resetValue, resetValue, resetValue },
+                    ref expectedNumWritten);
+        }
+        catch (Exception) { }
+
+        try
+        {
+            Janelia.NiDaqMx.OnDestroy();
+        }
+        catch (Exception) { }
     }
 
     [Serializable]

--- a/TalkToNiDaq_LED_CylinderRotation.cs
+++ b/TalkToNiDaq_LED_CylinderRotation.cs
@@ -1,0 +1,191 @@
+using System;
+using UnityEngine;
+using static Janelia.NiDaqMx;
+
+public class TalkToNiDaq_LED_CylinderRotation : MonoBehaviour
+{
+    [Header("Cylinder Reference")]
+    [Tooltip("Drag the GameObject with AnimateCylinderTexture here. If left empty, it will be found automatically.")]
+    public AnimateCylinderTexture cylinderTexture;
+
+    [Header("LED Angle Ranges (signed degrees, -180 to 180)")]
+    [Tooltip("LED is ON when the cylinder azimuth falls within any of these ranges.")]
+    public AngleRange[] ledOnAngleRanges = new AngleRange[]
+    {
+        new AngleRange { minAngle = 150f, maxAngle = 180f },
+        new AngleRange { minAngle = -180f, maxAngle = -150f }
+    };
+
+    [Header("Debug")]
+    public bool showEachWrite = false;
+    public bool showEachRead = false;
+
+    private NiDaqLedLogEntry _currentLogEntry = new NiDaqLedLogEntry();
+    private Janelia.NiDaqMx.InputParams _inputParams;
+    private Janelia.NiDaqMx.OutputParams _outputParams;
+    private double[] _readData;
+    private double[] _writeData;
+    private bool odd = true;
+
+    [Serializable]
+    public struct AngleRange
+    {
+        [Range(-180f, 180f)] public float minAngle;
+        [Range(-180f, 180f)] public float maxAngle;
+    }
+
+    private void Start()
+    {
+        if (cylinderTexture == null)
+        {
+            cylinderTexture = FindObjectOfType<AnimateCylinderTexture>();
+            if (cylinderTexture == null)
+            {
+                Debug.LogError("TalkToNiDaq_LED_CylinderRotation: No AnimateCylinderTexture found in scene.");
+                return;
+            }
+        }
+
+        _inputParams = new Janelia.NiDaqMx.InputParams
+        {
+            ChannelNames = new string[] { "ai0", "ai1", "ai2" }
+        };
+        _readData = new double[_inputParams.SampleBufferSize];
+
+        if (!Janelia.NiDaqMx.CreateInputs(_inputParams))
+        {
+            Debug.LogError("Creating input failed");
+            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
+            return;
+        }
+
+        _outputParams = new Janelia.NiDaqMx.OutputParams
+        {
+            ChannelNames = new string[] { "ao0", "ao1", "ao2" },
+            VoltageMin = -5,
+            VoltageMax = 5
+        };
+
+        if (!Janelia.NiDaqMx.CreateOutputs(_outputParams))
+        {
+            Debug.LogError("Creating output failed");
+            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
+            return;
+        }
+
+        _writeData = new double[3] {
+            _outputParams.VoltageMin,
+            _outputParams.VoltageMin,
+            _outputParams.VoltageMin
+        };
+    }
+
+    private void Update()
+    {
+        if (cylinderTexture == null)
+            return;
+
+        // Read NiDaq inputs
+        int numReadPerChannel = 0;
+        if (Janelia.NiDaqMx.ReadFromInputs(_inputParams, ref _readData, ref numReadPerChannel))
+        {
+            if (numReadPerChannel > 0)
+            {
+                for (int i = 0; i < numReadPerChannel; i++)
+                {
+                    int j = IndexInReadBuffer(0, numReadPerChannel, i);
+                    int k = IndexInReadBuffer(1, numReadPerChannel, i);
+                    int l = IndexInReadBuffer(2, numReadPerChannel, i);
+                    _currentLogEntry.tracePD = _readData[j];
+                    _currentLogEntry.imgFrameTrigger = _readData[k];
+                    _currentLogEntry.ledTrigger = _readData[l];
+                }
+            }
+        }
+        else
+        {
+            Debug.LogWarning("Read from input failed");
+            Debug.LogWarning(Janelia.NiDaqMx.GetLatestError());
+        }
+
+        if (showEachRead)
+        {
+            Debug.Log($"tracePD: {_currentLogEntry.tracePD}, imgFrameTrigger: {_currentLogEntry.imgFrameTrigger}, ledTrigger: {_currentLogEntry.ledTrigger}");
+        }
+
+        // Get cylinder azimuth and convert from 0-360 to signed -180 to 180
+        float azimuth0to360 = cylinderTexture.AzimuthDeg;
+        float signedAzimuth = azimuth0to360 > 180f ? azimuth0to360 - 360f : azimuth0to360;
+
+        // Check if azimuth falls within any LED-ON range
+        bool ledOn = false;
+        for (int i = 0; i < ledOnAngleRanges.Length; i++)
+        {
+            float min = ledOnAngleRanges[i].minAngle;
+            float max = ledOnAngleRanges[i].maxAngle;
+            if (signedAzimuth >= min && signedAzimuth <= max)
+            {
+                ledOn = true;
+                break;
+            }
+        }
+
+        // ao0: toggling photodiode signal
+        _writeData[0] = odd ? _outputParams.VoltageMax : _outputParams.VoltageMin;
+        odd = !odd;
+
+        // ao1: rotation Y modulation
+        double rotationY = transform.rotation.eulerAngles.y;
+        double modulator = (_outputParams.VoltageMax - _outputParams.VoltageMin) / 360.0;
+        _writeData[1] = rotationY * modulator + _outputParams.VoltageMin;
+
+        // ao2: LED based on cylinder rotation
+        _writeData[2] = ledOn ? _outputParams.VoltageMax : _outputParams.VoltageMin;
+
+        // Log
+        _currentLogEntry.cylinderAzimuth = signedAzimuth;
+        _currentLogEntry.ledState = ledOn ? 1.0 : 0.0;
+        Janelia.Logger.Log(_currentLogEntry);
+
+        // Write outputs to DAQ
+        int expectedNumWritten = _writeData.Length;
+        if (!Janelia.NiDaqMx.WriteToOutputs(_outputParams, _writeData, ref expectedNumWritten))
+        {
+            Debug.LogError("Write to outputs failed");
+            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
+        }
+        else if (showEachWrite)
+        {
+            Debug.Log($"Azimuth: {signedAzimuth:F1}° | LED: {(ledOn ? "ON" : "OFF")} | Write: [{_writeData[0]:F2}, {_writeData[1]:F2}, {_writeData[2]:F2}]");
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (_writeData == null || _outputParams == null)
+            return;
+
+        double resetValue = _outputParams.VoltageMin;
+        int expectedNumWritten = _writeData.Length;
+
+        if (!Janelia.NiDaqMx.WriteToOutputs(_outputParams,
+                new double[] { resetValue, resetValue, resetValue },
+                ref expectedNumWritten))
+        {
+            Debug.LogError("Reset write failed on destroy");
+            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
+        }
+
+        Janelia.NiDaqMx.OnDestroy();
+    }
+
+    [Serializable]
+    private class NiDaqLedLogEntry : Janelia.Logger.Entry
+    {
+        public double tracePD;
+        public double imgFrameTrigger;
+        public double ledTrigger;
+        public float cylinderAzimuth;
+        public double ledState;
+    }
+}

--- a/TalkToNiDaq_LED_MovieProtocol.cs
+++ b/TalkToNiDaq_LED_MovieProtocol.cs
@@ -184,18 +184,22 @@ public class TalkToNiDaq_LED_MovieProtocol : MonoBehaviour
         if (_writeData == null || _outputParams == null)
             return;
 
-        double resetValue = _outputParams.VoltageMin;
-        int expectedNumWritten = _writeData.Length;
-
-        if (!Janelia.NiDaqMx.WriteToOutputs(_outputParams,
-                new double[] { resetValue, resetValue, resetValue },
-                ref expectedNumWritten))
+        try
         {
-            Debug.LogError("Reset write failed on destroy");
-            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
-        }
+            double resetValue = _outputParams.VoltageMin;
+            int expectedNumWritten = _writeData.Length;
 
-        Janelia.NiDaqMx.OnDestroy();
+            Janelia.NiDaqMx.WriteToOutputs(_outputParams,
+                    new double[] { resetValue, resetValue, resetValue },
+                    ref expectedNumWritten);
+        }
+        catch (Exception) { }
+
+        try
+        {
+            Janelia.NiDaqMx.OnDestroy();
+        }
+        catch (Exception) { }
     }
 
     [Serializable]

--- a/TalkToNiDaq_LED_MovieProtocol.cs
+++ b/TalkToNiDaq_LED_MovieProtocol.cs
@@ -1,0 +1,210 @@
+using System;
+using System.IO;
+using UnityEngine;
+using static Janelia.NiDaqMx;
+
+public class TalkToNiDaq_LED_MovieProtocol : MonoBehaviour
+{
+    [Header("LED Trigger: Specific Filenames")]
+    [Tooltip("LED turns ON when the displayed PNG matches any of these filenames (e.g., \"1.png\", \"special.png\").")]
+    public string[] ledOnTextureNames = new string[0];
+
+    [Header("LED Trigger: Numeric Ranges")]
+    [Tooltip("LED turns ON when the numeric part of the PNG filename falls within any of these ranges (inclusive).")]
+    public TextureNumberRange[] ledOnTextureRanges = new TextureNumberRange[0];
+
+    [Header("Debug")]
+    public bool showEachWrite = false;
+    public bool showEachRead = false;
+
+    private MovieProtocolLedLogEntry _currentLogEntry = new MovieProtocolLedLogEntry();
+    private Janelia.NiDaqMx.InputParams _inputParams;
+    private Janelia.NiDaqMx.OutputParams _outputParams;
+    private double[] _readData;
+    private double[] _writeData;
+    private bool odd = true;
+
+    [Serializable]
+    public struct TextureNumberRange
+    {
+        [Tooltip("First PNG number in range (inclusive), e.g., 500")]
+        public int fromNumber;
+        [Tooltip("Last PNG number in range (inclusive), e.g., 600")]
+        public int toNumber;
+    }
+
+    private void Start()
+    {
+        _inputParams = new Janelia.NiDaqMx.InputParams
+        {
+            ChannelNames = new string[] { "ai0", "ai1", "ai2" }
+        };
+        _readData = new double[_inputParams.SampleBufferSize];
+
+        if (!Janelia.NiDaqMx.CreateInputs(_inputParams))
+        {
+            Debug.LogError("TalkToNiDaq_LED_MovieProtocol: Creating input failed");
+            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
+            return;
+        }
+
+        _outputParams = new Janelia.NiDaqMx.OutputParams
+        {
+            ChannelNames = new string[] { "ao0", "ao1", "ao2" },
+            VoltageMin = -5,
+            VoltageMax = 5
+        };
+
+        if (!Janelia.NiDaqMx.CreateOutputs(_outputParams))
+        {
+            Debug.LogError("TalkToNiDaq_LED_MovieProtocol: Creating output failed");
+            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
+            return;
+        }
+
+        _writeData = new double[3] {
+            _outputParams.VoltageMin,
+            _outputParams.VoltageMin,
+            _outputParams.VoltageMin
+        };
+    }
+
+    private void Update()
+    {
+        // Read NiDaq inputs
+        int numReadPerChannel = 0;
+        if (Janelia.NiDaqMx.ReadFromInputs(_inputParams, ref _readData, ref numReadPerChannel))
+        {
+            if (numReadPerChannel > 0)
+            {
+                for (int i = 0; i < numReadPerChannel; i++)
+                {
+                    int j = IndexInReadBuffer(0, numReadPerChannel, i);
+                    int k = IndexInReadBuffer(1, numReadPerChannel, i);
+                    int l = IndexInReadBuffer(2, numReadPerChannel, i);
+                    _currentLogEntry.tracePD = _readData[j];
+                    _currentLogEntry.imgFrameTrigger = _readData[k];
+                    _currentLogEntry.ledTrigger = _readData[l];
+                }
+            }
+        }
+        else
+        {
+            Debug.LogWarning("Read from input failed");
+            Debug.LogWarning(Janelia.NiDaqMx.GetLatestError());
+        }
+
+        if (showEachRead)
+        {
+            Debug.Log($"tracePD: {_currentLogEntry.tracePD}, imgFrameTrigger: {_currentLogEntry.imgFrameTrigger}, ledTrigger: {_currentLogEntry.ledTrigger}");
+        }
+
+        // Get the currently displayed texture name from BackgroundChanger
+        string currentTexture = Janelia.BackgroundChanger.CurrentTextureName;
+
+        // Check if LED should be ON
+        bool ledOn = false;
+        if (!string.IsNullOrEmpty(currentTexture))
+        {
+            ledOn = IsTextureInNameList(currentTexture) || IsTextureInNumberRange(currentTexture);
+        }
+
+        // ao0: toggling photodiode signal
+        _writeData[0] = odd ? _outputParams.VoltageMax : _outputParams.VoltageMin;
+        odd = !odd;
+
+        // ao1: rotation Y modulation
+        double rotationY = transform.rotation.eulerAngles.y;
+        double modulator = (_outputParams.VoltageMax - _outputParams.VoltageMin) / 360.0;
+        _writeData[1] = rotationY * modulator + _outputParams.VoltageMin;
+
+        // ao2: LED based on current texture
+        _writeData[2] = ledOn ? _outputParams.VoltageMax : _outputParams.VoltageMin;
+
+        // Log
+        _currentLogEntry.currentTexture = currentTexture;
+        _currentLogEntry.ledState = ledOn ? 1.0 : 0.0;
+        Janelia.Logger.Log(_currentLogEntry);
+
+        // Write outputs to DAQ
+        int expectedNumWritten = _writeData.Length;
+        if (!Janelia.NiDaqMx.WriteToOutputs(_outputParams, _writeData, ref expectedNumWritten))
+        {
+            Debug.LogError("Write to outputs failed");
+            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
+        }
+        else if (showEachWrite)
+        {
+            Debug.Log($"Texture: {currentTexture} | LED: {(ledOn ? "ON" : "OFF")} | Write: [{_writeData[0]:F2}, {_writeData[1]:F2}, {_writeData[2]:F2}]");
+        }
+    }
+
+    /// <summary>
+    /// Check if the texture filename matches any entry in the explicit name list.
+    /// </summary>
+    private bool IsTextureInNameList(string textureName)
+    {
+        for (int i = 0; i < ledOnTextureNames.Length; i++)
+        {
+            if (string.Equals(textureName, ledOnTextureNames[i], StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Check if the numeric part of the texture filename falls within any configured range.
+    /// E.g., "523.png" → 523 → checked against ranges like {500, 600}.
+    /// </summary>
+    private bool IsTextureInNumberRange(string textureName)
+    {
+        if (ledOnTextureRanges.Length == 0)
+            return false;
+
+        // Strip extension and try to parse the filename as a number
+        string nameWithoutExt = Path.GetFileNameWithoutExtension(textureName);
+        if (!int.TryParse(nameWithoutExt, out int textureNumber))
+            return false;
+
+        for (int i = 0; i < ledOnTextureRanges.Length; i++)
+        {
+            if (textureNumber >= ledOnTextureRanges[i].fromNumber &&
+                textureNumber <= ledOnTextureRanges[i].toNumber)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void OnDestroy()
+    {
+        if (_writeData == null || _outputParams == null)
+            return;
+
+        double resetValue = _outputParams.VoltageMin;
+        int expectedNumWritten = _writeData.Length;
+
+        if (!Janelia.NiDaqMx.WriteToOutputs(_outputParams,
+                new double[] { resetValue, resetValue, resetValue },
+                ref expectedNumWritten))
+        {
+            Debug.LogError("Reset write failed on destroy");
+            Debug.LogError(Janelia.NiDaqMx.GetLatestError());
+        }
+
+        Janelia.NiDaqMx.OnDestroy();
+    }
+
+    [Serializable]
+    private class MovieProtocolLedLogEntry : Janelia.Logger.Entry
+    {
+        public double tracePD;
+        public double imgFrameTrigger;
+        public double ledTrigger;
+        public string currentTexture;
+        public double ledState;
+    }
+}

--- a/org.janelia.background/Assets/Resources/TextureMix.shader
+++ b/org.janelia.background/Assets/Resources/TextureMix.shader
@@ -37,8 +37,8 @@ Shader "Unlit/TextureMix" {
             }
 
             fixed4 frag (v2f i) : SV_Target {
-                fixed4 color1 = tex2D(_MainTex, i.uv + _MainTex_ST.xy);
-                fixed4 color2 = tex2D(_SecondTex, i.uv + _SecondTex_ST.xy);
+                fixed4 color1 = tex2D(_MainTex, i.uv + _MainTex_ST.zw);
+                fixed4 color2 = tex2D(_SecondTex, i.uv + _SecondTex_ST.zw);
 
                 // Porter and Duff, color2 "over" color1.
                 float finalAlpha = color2.a + color1.a * (1.0 - color2.a);

--- a/org.janelia.background/Runtime/BackgroundChanger.cs
+++ b/org.janelia.background/Runtime/BackgroundChanger.cs
@@ -190,6 +190,7 @@ namespace Janelia
                 if (_material != null)
                 {
                     _material.SetTexture("_MainTex", _separatorTexture);
+                    _currentTextureName = "";
 
                     _currentChangingToSeparatorTextureLog.separatorTextureDurationSecs = _spec.separatorDurationSecs;
                     Logger.Log(_currentChangingToSeparatorTextureLog);
@@ -202,6 +203,7 @@ namespace Janelia
                 {
                     Texture2D texture = LoadTexture(_texturePaths[_current]);
                     _material.SetTexture("_MainTex", texture);
+                    _currentTextureName = Path.GetFileName(_texturePaths[_current]);
 
                     _currentChangingTextureLog.backgroundTextureNowInUse = _texturePaths[_current];
                     _currentChangingTextureLog.durationSecs = _spec.durationSecs;
@@ -222,6 +224,11 @@ namespace Janelia
         private static GameObject _object;
         private static bool _splashIsFinished = false;
         private static int _current = 0;
+
+        // Public read-only access to the filename of the currently displayed texture.
+        // Empty string when the separator (not a stimulus PNG) is being shown.
+        public static string CurrentTextureName => _currentTextureName;
+        private static string _currentTextureName = "";
 
         [Serializable]
         private class ChangingTextureLog : Logger.Entry


### PR DESCRIPTION
- TalkToNiDaq_LED_CylinderRotation: triggers LED (ao2) based on configurable cylinder azimuth angle ranges (signed degrees -180 to 180)
- TalkToNiDaq_LED_MovieProtocol: triggers LED (ao2) when specific PNGs are displayed, supporting both filename matching and numeric ranges
- AnimateCylinderTexture: expose AzimuthDeg as public read-only property
- BackgroundChanger: expose CurrentTextureName as public static property