### PR TITLE
count packets lost in the ringbuffer

### DIFF
--- a/org.janelia.io/Runtime/RingBuffer.cs
+++ b/org.janelia.io/Runtime/RingBuffer.cs
@@ -20,8 +20,8 @@ namespace Janelia
             }
         }
 
-        // Debug counter: incremented each time an unread slot is overwritten.
-        public volatile int debugCounterOverwrite = 0;
+        // Incremented each time an unread slot is overwritten.
+        public volatile int overwriteCount = 0;
 
         // Give the specified bytes to the next available buffer in the ring.  The data is copied.
         public void Give(Byte[] given)
@@ -33,7 +33,7 @@ namespace Janelia
                 if (_count == _items.Length)
                 {
                     _iTake = (_iTake + 1) % _items.Length;
-                    debugCounterOverwrite++;
+                    overwriteCount++;
                 }
                 else
                     _count++;

--- a/org.janelia.io/Runtime/RingBuffer.cs
+++ b/org.janelia.io/Runtime/RingBuffer.cs
@@ -20,6 +20,9 @@ namespace Janelia
             }
         }
 
+        // Debug counter: incremented each time an unread slot is overwritten.
+        public volatile int debugCounterOverwrite = 0;
+
         // Give the specified bytes to the next available buffer in the ring.  The data is copied.
         public void Give(Byte[] given)
         {
@@ -28,7 +31,10 @@ namespace Janelia
                 Buffer.BlockCopy(given, 0, _items[_iGive].bytes, 0, given.Length);
                 _items[_iGive].timestampMs = DateTimeOffset.Now.ToUnixTimeMilliseconds();
                 if (_count == _items.Length)
+                {
                     _iTake = (_iTake + 1) % _items.Length;
+                    debugCounterOverwrite++;
+                }
                 else
                     _count++;
                 _iGive = (_iGive + 1) % _items.Length;

--- a/org.janelia.io/Runtime/SocketMessageReader.cs
+++ b/org.janelia.io/Runtime/SocketMessageReader.cs
@@ -100,8 +100,8 @@ namespace Janelia
         }
 
         // Diagnostic counters exposed from the underlying socket reader.
-        public int DebugPacketCounter => _socketReader.debugPacketCounter;
-        public int DebugCounterOverwrite => _socketReader.DebugCounterOverwrite;
+        public int PacketCount => _socketReader.packetCount;
+        public int OverwriteCount => _socketReader.OverwriteCount;
 
         private void SeparateMessages(Byte[] dataFromSocket, ref List<int> indices)
         {

--- a/org.janelia.io/Runtime/SocketMessageReader.cs
+++ b/org.janelia.io/Runtime/SocketMessageReader.cs
@@ -99,6 +99,10 @@ namespace Janelia
             _socketReader.OnDisable();
         }
 
+        // Diagnostic counters exposed from the underlying socket reader.
+        public int DebugPacketCounter => _socketReader.debugPacketCounter;
+        public int DebugCounterOverwrite => _socketReader.DebugCounterOverwrite;
+
         private void SeparateMessages(Byte[] dataFromSocket, ref List<int> indices)
         {
             indices.Clear();

--- a/org.janelia.io/Runtime/SocketReader.cs
+++ b/org.janelia.io/Runtime/SocketReader.cs
@@ -19,8 +19,8 @@ namespace Janelia
         // Setting this flag to `true` will reduce performance.,
         public bool debugSlowly = false;
 
-        // Count lost messages.
-        public volatile int debugPacketCounter = 0;
+        // Count of received packets.
+        public volatile int packetCount = 0;
 
         // Only TCP needs `connectRetryMs`.
         public SocketReader(string hostname = "127.0.0.1", int port = 2000, int bufferSizeBytes = 1024, int readBufferCount = 240, bool useUDP = true, int connectRetryMs = 5000)
@@ -70,7 +70,7 @@ namespace Janelia
         }
 
         // Diagnostic: number of ring buffer overwrites (unread messages silently dropped).
-        public int DebugCounterOverwrite => _ringBuffer.debugCounterOverwrite;
+        public int OverwriteCount => _ringBuffer.overwriteCount;
 
         public bool ReadyToWrite()
         {
@@ -205,7 +205,7 @@ namespace Janelia
                         if (debugSlowly)
                             Debug.Log("SocketReader read " + length + " bytes");
 
-                        debugPacketCounter++;
+                        packetCount++;
                         _ringBuffer.Give(readBuffer);
                         Array.Clear(readBuffer, 0, length);
 
@@ -253,6 +253,7 @@ namespace Janelia
                                 if (debugSlowly)
                                     Debug.Log("SocketReader read " + length + " bytes");
 
+                                packetCount++;
                                 _ringBuffer.Give(readBuffer);
                                 Array.Clear(readBuffer, 0, length);
 

--- a/org.janelia.io/Runtime/SocketReader.cs
+++ b/org.janelia.io/Runtime/SocketReader.cs
@@ -19,6 +19,9 @@ namespace Janelia
         // Setting this flag to `true` will reduce performance.,
         public bool debugSlowly = false;
 
+        // Count lost messages.
+        public volatile int debugPacketCounter = 0;
+
         // Only TCP needs `connectRetryMs`.
         public SocketReader(string hostname = "127.0.0.1", int port = 2000, int bufferSizeBytes = 1024, int readBufferCount = 240, bool useUDP = true, int connectRetryMs = 5000)
         {
@@ -65,6 +68,9 @@ namespace Janelia
         {
             return _ringBuffer.Take(ref taken, ref timestampMs);
         }
+
+        // Diagnostic: number of ring buffer overwrites (unread messages silently dropped).
+        public int DebugCounterOverwrite => _ringBuffer.debugCounterOverwrite;
 
         public bool ReadyToWrite()
         {
@@ -199,6 +205,7 @@ namespace Janelia
                         if (debugSlowly)
                             Debug.Log("SocketReader read " + length + " bytes");
 
+                        debugPacketCounter++;
                         _ringBuffer.Give(readBuffer);
                         Array.Clear(readBuffer, 0, length);
 

--- a/org.janelia.io/Tests/Runtime/RingBufferTest.cs
+++ b/org.janelia.io/Tests/Runtime/RingBufferTest.cs
@@ -76,5 +76,40 @@ namespace Janelia
             didTake = buffer.Take(ref taken, ref timestamp);
             Assert.IsFalse(didTake);
         }
+
+        [Test]
+        public static void TestOverwriteDiagnosticCounter()
+        {
+            int ItemCount = 4;
+            int ItemSizeBytes = 32;
+            RingBuffer buffer = new RingBuffer(ItemCount, ItemSizeBytes);
+
+            Assert.AreEqual(0, buffer.debugCounterOverwrite);
+
+            buffer.Give(Encoding.ASCII.GetBytes("one"));
+            buffer.Give(Encoding.ASCII.GetBytes("two"));
+            buffer.Give(Encoding.ASCII.GetBytes("three"));
+            buffer.Give(Encoding.ASCII.GetBytes("four"));
+            Assert.AreEqual(0, buffer.debugCounterOverwrite);
+
+            buffer.Give(Encoding.ASCII.GetBytes("five"));
+            Assert.AreEqual(1, buffer.debugCounterOverwrite);
+
+            buffer.Give(Encoding.ASCII.GetBytes("six"));
+            Assert.AreEqual(2, buffer.debugCounterOverwrite);
+
+            Byte[] taken = new Byte[ItemSizeBytes];
+            long timestamp = 0;
+            buffer.Take(ref taken, ref timestamp);
+            buffer.Take(ref taken, ref timestamp);
+
+            buffer.Give(Encoding.ASCII.GetBytes("seven"));
+            Assert.AreEqual(2, buffer.debugCounterOverwrite);
+            buffer.Give(Encoding.ASCII.GetBytes("eight"));
+            Assert.AreEqual(2, buffer.debugCounterOverwrite);
+
+            buffer.Give(Encoding.ASCII.GetBytes("nine"));
+            Assert.AreEqual(3, buffer.debugCounterOverwrite);
+        }
     }
 }

--- a/org.janelia.io/Tests/Runtime/RingBufferTest.cs
+++ b/org.janelia.io/Tests/Runtime/RingBufferTest.cs
@@ -84,19 +84,19 @@ namespace Janelia
             int ItemSizeBytes = 32;
             RingBuffer buffer = new RingBuffer(ItemCount, ItemSizeBytes);
 
-            Assert.AreEqual(0, buffer.debugCounterOverwrite);
+            Assert.AreEqual(0, buffer.overwriteCount);
 
             buffer.Give(Encoding.ASCII.GetBytes("one"));
             buffer.Give(Encoding.ASCII.GetBytes("two"));
             buffer.Give(Encoding.ASCII.GetBytes("three"));
             buffer.Give(Encoding.ASCII.GetBytes("four"));
-            Assert.AreEqual(0, buffer.debugCounterOverwrite);
+            Assert.AreEqual(0, buffer.overwriteCount);
 
             buffer.Give(Encoding.ASCII.GetBytes("five"));
-            Assert.AreEqual(1, buffer.debugCounterOverwrite);
+            Assert.AreEqual(1, buffer.overwriteCount);
 
             buffer.Give(Encoding.ASCII.GetBytes("six"));
-            Assert.AreEqual(2, buffer.debugCounterOverwrite);
+            Assert.AreEqual(2, buffer.overwriteCount);
 
             Byte[] taken = new Byte[ItemSizeBytes];
             long timestamp = 0;
@@ -104,12 +104,12 @@ namespace Janelia
             buffer.Take(ref taken, ref timestamp);
 
             buffer.Give(Encoding.ASCII.GetBytes("seven"));
-            Assert.AreEqual(2, buffer.debugCounterOverwrite);
+            Assert.AreEqual(2, buffer.overwriteCount);
             buffer.Give(Encoding.ASCII.GetBytes("eight"));
-            Assert.AreEqual(2, buffer.debugCounterOverwrite);
+            Assert.AreEqual(2, buffer.overwriteCount);
 
             buffer.Give(Encoding.ASCII.GetBytes("nine"));
-            Assert.AreEqual(3, buffer.debugCounterOverwrite);
+            Assert.AreEqual(3, buffer.overwriteCount);
         }
     }
 }

--- a/org.janelia.io/package.json
+++ b/org.janelia.io/package.json
@@ -1,7 +1,7 @@
 {
     "name": "org.janelia.io",
     "displayName": "Janelia Basic Input/Output",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "unity": "2019.2",
     "description": "Code for general device communication.",
     "keywords": ["VR"],


### PR DESCRIPTION
Add a simple counter to the number of messages replaced in the UDP packet ringbuffer. This should not add any significant load to the network receiver, but gives us a handle to debug issues like https://github.com/FlyVirtualReality/FlyVRExp/issues/37 and other previously unexplained network issues. For an application of these messages, see https://github.com/floesche/fly-unity-toolkit/pull/13