### PR TITLE
increase grid contrast

### DIFF
--- a/org.janelia.camera-utilities/Assets/Resources/PanoramicDisplay.shader
+++ b/org.janelia.camera-utilities/Assets/Resources/PanoramicDisplay.shader
@@ -333,8 +333,18 @@ Shader "Unlit/PanoramicDisplay"
                 }
 
                 float mask0 = tex2D(_TexMask, i.uv);
-                float mask = (1 - _MaskScale * mask0);
-                result *= mask;
+                if (_MaskScale < -0.5)
+                {
+                    // Calibration overlay mode: pattern lines (mask0 ≈ 0) are color-inverted
+                    // for guaranteed contrast against any background; other pixels are unchanged.
+                    float patternWeight = 1.0 - mask0;
+                    result = lerp(result, fixed4(1, 1, 1, 1) - result, patternWeight);
+                }
+                else
+                {
+                    float mask = (1 - _MaskScale * mask0);
+                    result *= mask;
+                }
 
                 fixed4 colorCorrection = tex2D(_TexColorCorrection, i.uv);
                 fixed4 scaledCorrection = fixed4(1, 1, 1, 1) - _ColorCorrectionScale * colorCorrection;

--- a/org.janelia.camera-utilities/Assets/Resources/PanoramicDisplay.shader
+++ b/org.janelia.camera-utilities/Assets/Resources/PanoramicDisplay.shader
@@ -134,6 +134,7 @@ Shader "Unlit/PanoramicDisplay"
 
             sampler2D _TexMask;
             float _MaskScale;
+            int _InvertColorAtMask0;
 
             sampler2D _TexColorCorrection;
             float _ColorCorrectionScale;
@@ -333,7 +334,7 @@ Shader "Unlit/PanoramicDisplay"
                 }
 
                 float mask0 = tex2D(_TexMask, i.uv);
-                if (_MaskScale < -0.5)
+                if (_InvertColorAtMask0)
                 {
                     // Calibration overlay mode: pattern lines (mask0 ≈ 0) are color-inverted
                     // for guaranteed contrast against any background; other pixels are unchanged.

--- a/org.janelia.camera-utilities/README.md
+++ b/org.janelia.camera-utilities/README.md
@@ -1,11 +1,12 @@
 # Janelia Camera Utilities
 
 ## Summary
-This package (org.janelia.camera-utilities) implements various utilities related to cameras.  For example, there is code to implement [off-axis perspective projection using the approach of Robert Kooima](http://csc.lsu.edu/~kooima/articles/genperspective/).
+
+This package (org.janelia.camera-utilities) implements various utilities related to cameras. For example, there is code to implement [off-axis perspective projection using the approach of Robert Kooima](http://csc.lsu.edu/~kooima/articles/genperspective/).
 
 ## Installation
-Follow the [installation instructions in the main repository](https://github.com/JaneliaSciComp/janelia-unity-toolkit/blob/master/README.md#installation).
 
+Follow the [installation instructions in the main repository](https://github.com/JaneliaSciComp/janelia-unity-toolkit/blob/master/README.md#installation).
 
 ## Details
 
@@ -15,33 +16,27 @@ Makes the attached camera use off-axis perspective projection.
 
 ### `Janelia.AdjoiningDisplaysCamera` and `Janelia.AdjoiningDisplaysCameraBuilder`
 
-Unity supports ["multi-display"](https://docs.unity3d.com/Manual/MultiDisplay.html), with a game having multiple cameras each shown on its own external display monitor.  Framerates above 60 Hz are not possible, though (as of 2019).
+Unity supports ["multi-display"](https://docs.unity3d.com/Manual/MultiDisplay.html), with a game having multiple cameras each shown on its own external display monitor. Framerates above 60 Hz are not possible, though (as of 2019).
 
-The `Janelia.AdjoiningDisplaysCamera` script implements an alternative with higher performance.  It combines the multiple camera images into one wide image that is associated with another, main camera.  The associated `Janelia.AdjoiningDisplaysCameraBuilder` builds a standalone executable with the special options to make the main camera's wide image extend across all the external displays, putting the appropriate part on each display.
+The `Janelia.AdjoiningDisplaysCamera` script implements an alternative with higher performance. It combines the multiple camera images into one wide image that is associated with another, main camera. The associated `Janelia.AdjoiningDisplaysCameraBuilder` builds a standalone executable with the special options to make the main camera's wide image extend across all the external displays, putting the appropriate part on each display.
 
 To use `AdjoiningDisplaysCamera` on Windows:
 
-1. Connect the external displays so they are numbered `2` through `N` in the Windows "Display Settings".  It is best if `2` is the left-most, and then the display numbers increase in order.  But if such an arrangement is not possible, see step 7., below.
+1. Connect the external displays so they are numbered `2` through `N` in the Windows "Display Settings". It is best if `2` is the left-most, and then the display numbers [increase in order](#adjoiningDisplay). But if such an arrangement is not possible, see step 7., below.
+2. In the "Display Settings", give each display the appropriate resolution (e.g., 1920 horizontal and 1080 vertical). The resolution must be the same for all displays, and they must have the same "Orientation".
+3. In the "Display Settings", make sure the "Multiple displays" fields says "Extend desktop to this display" (not "Duplicate desktop").
+4. In the Unity editor, add the `AdjoiningDisplaysCamera` script to one camera, such as the standard `Main Camera`. The "Target Display" for this camera should be "Display 1".
+5. Open `AdjoiningDisplaysCamera`'s "Display Cameras" section, set the "Size" field to the number of external displays, and set "Element `i`" to the camera for external display `i+1` (because the first "Element" is `0` but the first external display is `1`).
+6. Set `AdjoiningDisplaysCamera`'s "Display Width" and "Display Height" fields to match the external display resolution from step 2.
+7. If the left-most display in the Windows "Display Settings" is not `2`, then use its number as the value for the `AdjoiningDisplaysCamera`'s "Left Display Index" field.
+8. To build the standalone executable, use the menu item "File/Build and Make Adjoining-Displays Shortcut", which triggers code in `AdjoiningDisplaysCameraBuilder`. When the build is complete, it adds a shortcut file, `standalone`, to the Unity project's root folder. This shortcut runs the executable with the necessary [command line arguments](https://docs.unity3d.com/Manual/CommandLineArguments.html) to make the wide image extend onto all the external displays (i.e., `-popupwindow -screen-fullscreen 0 -monitor 2`)
 
 <p align="center">
-<img src="./adjoiningDisplaysCamera.PNG" height="400">
+<img src="./adjoiningDisplaysCamera.PNG" id="adjoiningDisplay" height="400">
 </p>
 
-2. In the "Display Settings", give each display the appropriate resolution (e.g., 1920 horizontal and 1080 vertical).  The resolution must be the same for all displays, and they must have the same "Orientation".
+When the game is running, it can display a _progress box_, a small square that alternates between black and white with each frame (so a photodiode attached to an oscilloscope can give an accurate indication of the frame rate).
 
-3. In the "Display Settings", make sure the "Multiple displays" fields says "Extend desktop to this display" (not "Duplicate desktop").
-
-4. In the Unity editor, add the `AdjoiningDisplaysCamera` script to one camera, such as the standard `Main Camera`.  The "Target Display" for this camera should be "Display 1".
-
-5. Open `AdjoiningDisplaysCamera`'s "Display Cameras" section, set the "Size" field to the number of external displays, and set "Element `i`" to the camera for external display `i+1` (because the first "Element" is `0` but the first external display is `1`).
-
-6. Set `AdjoiningDisplaysCamera`'s "Display Width" and "Display Height" fields to match the external display resolution from step 2.
-
-7. If the left-most display in the Windows "Display Settings" is not `2`, then use its number as the value for the `AdjoiningDisplaysCamera`'s "Left Display Index" field.
-
-8. To build the standalone executable, use the menu item "File/Build and Make Adjoining-Displays Shortcut", which triggers code in `AdjoiningDisplaysCameraBuilder`.  When the build is complete, it adds a shortcut file, `standalone`, to the Unity project's root folder.  This shortcut runs the executable with the necessary [command line arguments](https://docs.unity3d.com/Manual/CommandLineArguments.html) to make the wide image extend onto all the external displays (i.e., `-popupwindow -screen-fullscreen 0 -monitor 2`)
-
-When the game is running, it can display a _progress box_, a small square that alternates between black and white with each frame (so a photodiode attached to an oscilloscope can give an accurate indication of the frame rate).  
 - Pressing the `c` key changes which display shows the progress box.
 - Pressing the `p` key changes which corner of that display contains the progress box, with the fifth press hiding the progress box altogether.
 
@@ -49,11 +44,11 @@ Also, pressing the `m` key toggles mirroring of the displays on and off (useful 
 
 ### Frame Packing
 
-For animal participants who can see very fast changes (e.g., the _Drosophila_ fruit fly), the `Janelia.AdjoiningDisplaysCamera` supports an optional way of improving the visual smoothness through "frame packing" for DLP (digital light processing) projectors.   When ready to render frame _i_ at time _t\_i_, `AdjoiningDisplaysCamera` interpolates the camera pose (position, orientation) at three fractions of the interval from _t\_i-1_ to _t\_i_, and renders the scene at each fraction.  It then packs the resulting image from each fraction into one color channel of the image that is finally displayed.  [A DLP displays each color channel successively](https://www.benq.com/en-us/business/resource/trends/dlp-and-3lcd-projectors.html) for a fraction of the overall frame time, so the net effect is that the images for the interpolated camera poses are visible as frames at a higher frame rate to animals capable of seeing at the higher rate.  The higher-rate frames appear in grayscale instead of color, but that is acceptable in some applications.
+For animal participants who can see very fast changes (e.g., the _Drosophila_ fruit fly), the `Janelia.AdjoiningDisplaysCamera` supports an optional way of improving the visual smoothness through "frame packing" for DLP (digital light processing) projectors. When ready to render frame _i_ at time _t\_i_, `AdjoiningDisplaysCamera` interpolates the camera pose (position, orientation) at three fractions of the interval from _t\_i-1_ to _t\_i_, and renders the scene at each fraction. It then packs the resulting image from each fraction into one color channel of the image that is finally displayed. [A DLP displays each color channel successively](https://www.benq.com/en-us/business/resource/trends/dlp-and-3lcd-projectors.html) for a fraction of the overall frame time, so the net effect is that the images for the interpolated camera poses are visible as frames at a higher frame rate to animals capable of seeing at the higher rate. The higher-rate frames appear in grayscale instead of color, but that is acceptable in some applications.
 
-The Unity Editor's Inspector gives control over what the three fractions are, and what color channel corresponds to each fraction.  The fractions are controlled with three 0-to-1 sliders.  What color channel corresponds to each fraction is controled by a "packing order" value; a packing order of "GRB", for example, indicates that the first fraction corresponds to the display of green, the second fraction to red and the third to blue.
+The Unity Editor's Inspector gives control over what the three fractions are, and what color channel corresponds to each fraction. The fractions are controlled with three 0-to-1 sliders. What color channel corresponds to each fraction is controled by a "packing order" value; a packing order of "GRB", for example, indicates that the first fraction corresponds to the display of green, the second fraction to red and the third to blue.
 
-Note that while frame packing increases effective frame rate and smoothness, it does _not_ reduce latency.  In fact, it actually increases the latency by roughly the time to draw one frame.
+Note that while frame packing increases effective frame rate and smoothness, it does _not_ reduce latency. In fact, it actually increases the latency by roughly the time to draw one frame.
 
 ### Panoramic Display on Non-Flat Screens
 
@@ -67,8 +62,11 @@ The curvature of a display surface like a cylinder may distort the brightness of
 <img src="./panoramicDisplayCamera.PNG" height="400">
 </p>
 
-
 This compensating texture can be generated with the `Janelia.CameraUtilities.SetupCylinderProjectorEdgeBrightener` function, which computes computes the brightness attenuation with [Lambert's cosine law](https://en.wikipedia.org/wiki/Lambert%27s_cosine_law); it also includes a user-defined scale factor, that can be changed interactively to match the conditions of particular display surface. See the `ExampleUsingPanoramicDisplayCamera` script. An alternative is to write a custom function to generate the compensating texture, using the `CameraUtilities.SetupCylinderProjectorMaskDelegate` API.
+
+#### Calibration Overlay Mode
+
+Setting `surfaceMaskScale` to a negative value (e.g., `-1`) activates a calibration overlay mode in the `PanoramicDisplay` shader. In this mode, pixels where the mask texture is dark (value near 0, i.e., pattern lines) are rendered as the color-inverse of the scene, guaranteeing visible contrast against any background. Pixels where the mask texture is bright (value near 1) are left unchanged. This is useful for aligning the projector to the display surface, since the calibration pattern remains visible regardless of the scene content being projected.
 
 Screen curvature can also distort the color near the borders between projectors, so `PanoramicDisplayCamera` also takes a color correction texture. This correction texture can be generated with the `Janelia.CameraUtilities.SetupCylinderProjectorEdgeColorCorrector` function, which also uses the cosine law and includes user-defined parameters for the color to correct and for scaling.
 
@@ -76,7 +74,8 @@ Like `AdjoiningDisplaysCamera` described above, `PanoramicDisplayCamera` generat
 
 There are some constraints on the projectors and the cylindrical screen, so that projectors with a specified (horizontal) field of view can cover a cylinder of a specified radius with the adjoined images. The `PanoramicDisplayCamera.SetDisplaySurfaceData` function computes and prints out these constraints as it runs, so they appear in either the Unity editor console, or the `Player.log` text file, from the
 [place where Unity stores its logs](https://docs.unity3d.com/Manual/LogFiles.html). Example output is:
-```
+
+```{.shell}
 Please position projector 0 at (-9.97, 0.00, -5.76)
 Please position projector 1 at (0.00, 0.00, 11.52)
 Please position projector 2 at (9.97, 0.00, -5.76)
@@ -85,7 +84,8 @@ Please make the cylinder 5.100435 units tall.
 
 Using a display surface other than a cylinder involves calling `PanoramicDisplayCamera.SetDisplaySurfaceData` with custom arrays that describe where the pixels of the projectors map to 3D positions on the display surface. Custom arrays are also useful for a cylindrical display surface if there is to be regions of overlap between the images from adjacent projectors.
 
-The `PanoramicDisplayCamera` optionally displays a _progress box_, a small square that changes from black to white on alternate frames.  The true frame rate can be verified by positioning a photodiode where the progress box appears on the display, and observing the photodiode's signal with an oscilloscope.  The related fields on `PanormaicDisplayCamera` are:
-* `showProgressBox`: set to `true` to make the progress box visible.  The `p` key interactively toggles this value, but the changes are not saved across sessions.
-* `progressBoxPosition`: a `Vector2Int` whose value is the position, in pixels, of the progress box.  The `w`, `a`, `s,` and ,`d` keys interactively change this position, but the changed position is not saved across sessions.
-* `progressBoxSize`: the box's width (and height, since the box is a square), in pixels.
+The `PanoramicDisplayCamera` optionally displays a _progress box_, a small square that changes from black to white on alternate frames. The true frame rate can be verified by positioning a photodiode where the progress box appears on the display, and observing the photodiode's signal with an oscilloscope. The related fields on `PanoramicDisplayCamera` are:
+
+- `showProgressBox`: set to `true` to make the progress box visible. The `p` key interactively toggles this value. Changes are saved across sessions via `PlayerPrefs`.
+- `progressBoxPosition`: a `Vector2Int` whose value is the position, in pixels, of the progress box. The `w`, `a`, `s,` and ,`d` keys interactively change this position. Changes are saved across sessions via `PlayerPrefs`.
+- `progressBoxSize`: the box's width (and height, since the box is a square), in pixels.

--- a/org.janelia.camera-utilities/README.md
+++ b/org.janelia.camera-utilities/README.md
@@ -66,7 +66,7 @@ This compensating texture can be generated with the `Janelia.CameraUtilities.Set
 
 #### Calibration Overlay Mode
 
-Setting `surfaceMaskScale` to a negative value (e.g., `-1`) activates a calibration overlay mode in the `PanoramicDisplay` shader. In this mode, pixels where the mask texture is dark (value near 0, i.e., pattern lines) are rendered as the color-inverse of the scene, guaranteeing visible contrast against any background. Pixels where the mask texture is bright (value near 1) are left unchanged. This is useful for aligning the projector to the display surface, since the calibration pattern remains visible regardless of the scene content being projected.
+Setting `invertColorAtMask0` to `true` on `PanoramicDisplayCamera` activates a calibration overlay mode in the `PanoramicDisplay` shader. In this mode, pixels where the mask texture is dark (value near 0, i.e., pattern lines) are rendered as the color-inverse of the scene, guaranteeing visible contrast against any background. Pixels where the mask texture is bright (value near 1) are left unchanged. This is useful for aligning the projector to the display surface, since the calibration pattern remains visible regardless of the scene content being projected.
 
 Screen curvature can also distort the color near the borders between projectors, so `PanoramicDisplayCamera` also takes a color correction texture. This correction texture can be generated with the `Janelia.CameraUtilities.SetupCylinderProjectorEdgeColorCorrector` function, which also uses the cosine law and includes user-defined parameters for the color to correct and for scaling.
 
@@ -84,8 +84,11 @@ Please make the cylinder 5.100435 units tall.
 
 Using a display surface other than a cylinder involves calling `PanoramicDisplayCamera.SetDisplaySurfaceData` with custom arrays that describe where the pixels of the projectors map to 3D positions on the display surface. Custom arrays are also useful for a cylindrical display surface if there is to be regions of overlap between the images from adjacent projectors.
 
-The `PanoramicDisplayCamera` optionally displays a _progress box_, a small square that changes from black to white on alternate frames. The true frame rate can be verified by positioning a photodiode where the progress box appears on the display, and observing the photodiode's signal with an oscilloscope. The related fields on `PanoramicDisplayCamera` are:
+The public fields on `PanoramicDisplayCamera` are:
 
-- `showProgressBox`: set to `true` to make the progress box visible. The `p` key interactively toggles this value. Changes are saved across sessions via `PlayerPrefs`.
+- `surfaceMaskScale`: a 0-to-1 scaling factor for brightness compensation using the mask texture. Setting it to 0 disables compensation, and setting it to 1 gives full compensation. See the `ExampleUsingPanoramicDisplayCamera` script.
+- `surfaceColorCorrectionScale`: a 0-to-1 scaling factor for color correction. Setting it to 0 disables color correction.
+- `invertColorAtMask0`: set to `true` to activate [calibration overlay mode](#calibration-overlay-mode), where pixels at dark mask values are color-inverted for guaranteed contrast against any background.
+- `showProgressBox`: set to `true` to make a _progress box_ visible, a small square that changes from black to white on alternate frames. The true frame rate can be verified by positioning a photodiode where the progress box appears on the display, and observing the photodiode's signal with an oscilloscope. The `p` key interactively toggles this value. Changes are saved across sessions via `PlayerPrefs`.
 - `progressBoxPosition`: a `Vector2Int` whose value is the position, in pixels, of the progress box. The `w`, `a`, `s,` and ,`d` keys interactively change this position. Changes are saved across sessions via `PlayerPrefs`.
 - `progressBoxSize`: the box's width (and height, since the box is a square), in pixels.

--- a/org.janelia.camera-utilities/Runtime/PanoramicDisplayCamera.cs
+++ b/org.janelia.camera-utilities/Runtime/PanoramicDisplayCamera.cs
@@ -31,6 +31,7 @@ namespace Janelia
         // `SetDisplaySurfaceData`, below, and also in `ExampleUsingPanoramiceDisplayCamera.cs`.
         public float surfaceMaskScale = 1;
         public float surfaceColorCorrectionScale = 0;
+        public bool invertColorAtMask0 = false;
 
         // If the panorama is to be displayed with more than one external display or projector, the images for
         // all the displays are adjoined horizontally into a single wide image, and this image "bleeds" from
@@ -173,6 +174,7 @@ namespace Janelia
         {
             _material.SetFloat("_MaskScale", surfaceMaskScale);
             _material.SetFloat("_ColorCorrectionScale", surfaceColorCorrectionScale);
+            _material.SetInt("_InvertColorAtMask0", invertColorAtMask0 ? 1 : 0);
 
 #if PROGRESS_BOX
             if (Input.GetKeyDown(KeyCode.P))

--- a/org.janelia.camera-utilities/package.json
+++ b/org.janelia.camera-utilities/package.json
@@ -1,7 +1,7 @@
 {
     "name": "org.janelia.camera-utilities",
     "displayName": "Janelia Camera Utilities",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "unity": "2018.3",
     "description": "Utility code related to cameras.",
     "keywords": ["VR"],

--- a/org.janelia.camera-utilities/package.json
+++ b/org.janelia.camera-utilities/package.json
@@ -1,7 +1,7 @@
 {
     "name": "org.janelia.camera-utilities",
     "displayName": "Janelia Camera Utilities",
-    "version": "1.8.1",
+    "version": "1.9.0",
     "unity": "2018.3",
     "description": "Utility code related to cameras.",
     "keywords": ["VR"],


### PR DESCRIPTION
By default, the calibration grid appears black. Depending on the setup, this would make the calibration grid invisible. With this patch, the calibration lines use the highest contrast and are always visible when activated.