### PR TITLE
Modified BackgroundChanger to prevent premature quitting

### DIFF
--- a/org.janelia.background/README.md
+++ b/org.janelia.background/README.md
@@ -103,6 +103,19 @@ Each time the background texture is changed, an entry is written to the log file
 
 For now, at least, the `backgroundCylinderTexture2` parameter can be only the path to a single image, which will be reused for every texture in the sequence for `backgroundCylinderTexture`.
 
+The optional `"waitForTimeout"` field indicates that the stand-alone executable should not automatically stop when all the images have been displayed, but instead when running time reaches the value of the `timeoutSecs` session parameter (from [org.janelia.general package](https://github.com/JaneliaSciComp/janelia-unity-toolkit/tree/master/org.janelia.general)). For example:
+```json
+{
+    "durationSecs": 10,
+    "textures" : [
+        "textures/A.png",
+        "textures/B.png",
+        "textures/C.png"
+    ],
+    "waitForTimeout": true
+}
+```
+
 ### `Janelia.BackgroundUtilities`
 
 #### `Janelia.BackgroundUtilities.SetCylinderTextureOffset`

--- a/org.janelia.background/Runtime/BackgroundChanger.cs
+++ b/org.janelia.background/Runtime/BackgroundChanger.cs
@@ -24,6 +24,7 @@ namespace Janelia
             public float durationSecs = 1;
             public string separatorTexture;
             public float separatorDurationSecs;
+            public bool quitWhenDone = true;
         }
 
         public static void Initialize(Spec spec, string specFilePath)
@@ -182,7 +183,8 @@ namespace Janelia
                 UseSeparatorTexture();
                 yield return new WaitForSeconds(_spec.separatorDurationSecs);
 
-                Application.Quit();
+                if (_spec.quitWhenDone)
+                    Application.Quit();
             }
 
             private void UseSeparatorTexture()

--- a/org.janelia.background/Runtime/BackgroundChanger.cs
+++ b/org.janelia.background/Runtime/BackgroundChanger.cs
@@ -24,7 +24,8 @@ namespace Janelia
             public float durationSecs = 1;
             public string separatorTexture;
             public float separatorDurationSecs;
-            public bool quitWhenDone = true;
+            // True: quit per org.janelia.general timeoutSecs. False: quit when images are exhausted.
+            public bool waitForTimeout = false;
         }
 
         public static void Initialize(Spec spec, string specFilePath)
@@ -183,7 +184,7 @@ namespace Janelia
                 UseSeparatorTexture();
                 yield return new WaitForSeconds(_spec.separatorDurationSecs);
 
-                if (_spec.quitWhenDone)
+                if (!_spec.waitForTimeout)
                     Application.Quit();
             }
 

--- a/org.janelia.background/package.json
+++ b/org.janelia.background/package.json
@@ -1,7 +1,7 @@
 {
     "name": "org.janelia.background",
     "displayName": "Janelia Background Displays",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "unity": "2019.3",
     "description": "Support for background displays.",
     "keywords": ["VR"],


### PR DESCRIPTION
Default behavior is BackgroundChanger.cs quits when textures elapse, but if quitWhenDone = false is passed in the json, timeoutSecs duration is allowed to elapse before closing.